### PR TITLE
Passage de Matrix dans son propre fichier et correction du Display (+ formatage)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod matrix;
+
 /*
-!TODO 
+!TODO
 - print
 - mutl
 - ...
@@ -9,147 +11,19 @@
 mod tests {
     use crate::matrix::Matrix;
 
-
     #[test]
     fn it_works() {
         let tab = vec![vec![4., 5., 2.], vec![2., 8., 3.]];
         let expect_tab = vec![vec![8., 10., 4.], vec![4., 16., 6.]];
         let _m1: Matrix<f32, 2, 3> = Matrix::from(tab.clone());
-        let _m2: Matrix<f32,2,3> = Matrix::from(tab.clone());
+        let _m2: Matrix<f32, 2, 3> = Matrix::from(tab.clone());
 
+        let expect_m: Matrix<f32, 2, 3> = Matrix::from(expect_tab);
 
-        let expect_m: Matrix<f32,2,3> = Matrix::from(expect_tab);
-
-        println!("expect_m :{}",expect_m);
-        println!("{}",_m1+_m2);
+        println!("expect_m :{}", expect_m);
+        println!("{}", _m1 + _m2);
 
         assert_eq!(_m1 + _m2, expect_m);
         assert_eq!(_m2 + _m1, expect_m);
-        
-    }
-}
-
-pub mod matrix {
-    use core::fmt;
-
-
-    //definition of Matrix
-    #[derive(PartialEq,Debug,Clone)]
-    pub struct Matrix<T :Default, const N: usize, const M: usize>{
-        inner: [[T; M]; N],
-    }
-
-    //definition of a default 
-    impl<T: std::default::Default + std::marker::Copy, const N: usize, const M: usize> Default
-        for Matrix<T, N, M>{
-        fn default() -> Self {
-            Self {
-                inner: [[T::default(); M]; N],
-            }
-        }
-    }
-
-    //definition using a vec
-    impl<T: std::default::Default + std::marker::Copy, const N: usize, const M: usize>
-        From<Vec<Vec<T>>> for Matrix<T, N, M>{
-        fn from(tab: Vec<Vec<T>>) -> Self {
-            if cfg!(debug_assertion) {
-                assert_eq!(tab.len(), N);
-                for row in &tab{
-                    assert_eq!(row.len(), M);
-                }
-            }
-
-
-            let mut arr: [[T; M]; N] = [[T::default(); M]; N];
-            for (i, row) in tab.into_iter().enumerate() {
-                for (j, val) in row.into_iter().enumerate() {
-                    arr[i][j] = val;
-                }
-            }
-            Self { inner: arr }
-        }
-    }
-
-    //definition using an array
-    impl<T: std::default::Default, const N: usize, const M: usize> From<[[T; M]; N]>
-        for Matrix<T, N, M>{
-        fn from(arr: [[T; M]; N]) -> Self {
-            Self { inner: arr }
-        }
-    }
-
-    // mark : BUG
-    /*implementation to use print
-    it can not display f for the moment, I try to understand why*/
-    impl<T :std::default::Default + fmt::Display, const N :usize, const M:usize> fmt::Display for Matrix<T,N,M>{
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            
-            match write!(f,""){
-                Ok(_) =>             
-                {for i in 0..self.inner.len(){
-                    println!();
-                    for j in 0..self.inner[i].len(){
-                        print!("{} ", self.inner[i][j]);
-                    }
-                }
-                println!();
-                Ok(())},
-                Err(e) => {
-                    print!("{}",e);
-                    Err(e)
-                }
-            }
-
-        }
-        
-    }
-
-
-    //implementation of Copy
-    impl<T :std::default::Default + std::marker::Copy, const N :usize, const M:usize> Copy for Matrix<T,N,M>{}
-
-    //definition for the operation with f32 as T
-    pub mod matrix_operation_f32{
-        use crate::matrix::Matrix;
-        use std::ops::*;
-        
-        //definition of the addition
-        impl<const N :usize, const M:usize> Add for Matrix<f32,N,M> {
-            type Output = Self;
-            fn add(self, rhs: Self) -> Self::Output {
-                let mut result = Self::default();
-                for (i, (row1, row2)) in self.inner.into_iter().zip(rhs.inner).enumerate(){
-                    for (j,(val1, val2)) in row1.into_iter().zip(row2).enumerate(){
-                        result.inner[i][j] = val1 + val2;
-                    }
-                }
-                result
-            }
-            
-    
-        }
-
-        /* //TODO 
-         implement a zeroed and a id trait to get a null matrix<f32> and an id matrix<f32>
-        TODO */  
-            
-
-
-        impl <const N :usize, const M:usize> Mul<Matrix<f32,M,N>> for Matrix<f32,N,M> {
-            type Output = Matrix<f32,M,M>;
-            fn mul(self, rhs: Matrix<f32,M,N>) -> Self::Output {
-                let mut result = Matrix::<f32,M,M>::default() ;
-                for i in 0..N{
-                    for j in 0..M{
-
-                    }
-                }
-
-                
-
-                result
-            }
-        }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,101 @@
+use std::default::Default;
+use std::fmt::{self, Display, Formatter};
+use std::marker::Copy;
+use std::ops::*;
+
+//definition of Matrix my_rust_matrix_lib
+#[derive(PartialEq, Debug, Clone)]
+pub struct Matrix<T: Default, const N: usize, const M: usize> {
+    inner: [[T; M]; N],
+}
+
+//definition of a default
+impl<T: Default + Copy, const N: usize, const M: usize> Default for Matrix<T, N, M> {
+    fn default() -> Self {
+        Self {
+            inner: [[T::default(); M]; N],
+        }
+    }
+}
+
+//definition using a vec
+impl<T: Default + Copy, const N: usize, const M: usize> From<Vec<Vec<T>>> for Matrix<T, N, M> {
+    fn from(tab: Vec<Vec<T>>) -> Self {
+        debug_assert_eq!(tab.len(), N);
+        for row in &tab {
+            debug_assert_eq!(row.len(), M);
+        }
+
+        let mut arr: [[T; M]; N] = [[T::default(); M]; N];
+        for (i, row) in tab.into_iter().enumerate() {
+            for (j, val) in row.into_iter().enumerate() {
+                arr[i][j] = val;
+            }
+        }
+        Self { inner: arr }
+    }
+}
+
+//definition using an array
+impl<T: Default, const N: usize, const M: usize> From<[[T; M]; N]> for Matrix<T, N, M> {
+    fn from(arr: [[T; M]; N]) -> Self {
+        Self { inner: arr }
+    }
+}
+
+// mark: BUG
+/*implementation to use print
+it can not display f for the moment, I try to understand why*/
+impl<T: Default + Display, const N: usize, const M: usize> Display for Matrix<T, N, M> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for i in 0..N {
+            for j in 0..M {
+                match write!(f, "{} ", self.inner[i][j]) {
+                    Ok(_) => (),
+                    Err(err) => return Err(err),
+                }
+            }
+
+            match writeln!(f, "") {
+                Ok(_) => (),
+                Err(err) => return Err(err),
+            };
+        }
+        Ok(())
+    }
+}
+
+//implementation of Copy
+impl<T: Default + Copy, const N: usize, const M: usize> Copy for Matrix<T, N, M> {}
+
+//definition for the operation with f32 as T
+
+//definition of the addition
+impl<const N: usize, const M: usize> Add for Matrix<f32, N, M> {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut result = Self::default();
+        for (i, (row1, row2)) in self.inner.into_iter().zip(rhs.inner).enumerate() {
+            for (j, (val1, val2)) in row1.into_iter().zip(row2).enumerate() {
+                result.inner[i][j] = val1 + val2;
+            }
+        }
+        result
+    }
+}
+
+/* //TODO
+    implement a zeroed and a id trait to get a null matrix<f32> and an id matrix<f32>
+TODO */
+
+impl<const N: usize, const M: usize> Mul<Matrix<f32, M, N>> for Matrix<f32, N, M> {
+    type Output = Matrix<f32, M, M>;
+    fn mul(self, rhs: Matrix<f32, M, N>) -> Self::Output {
+        let mut result = Matrix::<f32, M, M>::default();
+        for i in 0..N {
+            for j in 0..M {}
+        }
+
+        result
+    }
+}


### PR DESCRIPTION
Salut, je fais cette "PR" pour pouvoir te montrer et d'expliquer 2/3 petites choses, elle n'est pas faite pour être merge (tu t'en doutes bien, mais on précise si jamais). Pour qqu qui fait du rust depuis pas longtemps, c'est très bien.

En premier lieu, ton module `matrix_operation_f32`, elle va malheureusement t'être plus dérangeante qu'autre chose. Les modules servent pour encapsuler du code et les ranger. Le comportement de rust vis-a-vis des modules et de les ignorer s'ils sont pas demandés, c.-à-d. avec ton module pour pouvoir par exemple faire une addition, tu devras importer (via une `use crate::matrix::matrix_operation_f32`) le module de tes opérations, et cela, dans TOUS les fichiers qui demanderont l'usage des celle-ci. Donc je te conseille de ne jamais encapsuler pour le moment les `impl` dans des modules qui ne sont pas ce de ta structure de donne (struct, enum ou autres), tu apprendras au fur et à mesure a plus justement placer les impl au bon endroit.

En second lieu, la séparation en module fait la plutôt avec des fichiers, rust a un avantage de considérer les fichiers et dossier comme des modules du programme ce qui simplifie quand même beaucoup leurs gestions et leurs imports (tu apprendras plus tard les quelque "inconvénient" de qu'il y a dans les modules rust). Pour importer un module qui est un fichier se fera avec la ligne `mod nom_du_fichier`, tu n'as plus besoin du bloc de code qui fait ton module comme il est dès à présent dans le fichier `nom_du_fichier.rs`, je laisse découvrir comme utiliser les modules avec des dossiers.

Pour la gestion des imports évite le core quand tu as la std de disponible (c'est pas obligatoire, mais un c'est conseille, c'est plus simple pour la compréhension quand on débute de tout faire passer par la std). De plus quand tu te retrouves dans des cas comme `std::default::Default` ou `std::marker::Copy` qui apparaisse plus d'une fois. Fais en sorte de l'importer avec un `use` global à ton module et de simplement utiliser `Default` ou `Copy`, ça sera plus lisible. PAR CONTRE, dans le cas des `Result` (ou des `Option`) comme c'est qqc de très utilisé, il peut arriver comme avec `std::fmt::Result` que tu es un conflit de nom (rust ne fait pas la diff entre `std::result::Result` et `std::fmt::Result`) alors dans c'est cas là, ne fait pas `use std::fmt::Result` mais `use std::fmt`, tu n'importes plus l'enum mais le module, ça va te permettre d'avoir des `fmt::Result` qui est plus lisible sur la donnée renvoyer ou manipuler. Après tout ça c'est avec l'expérience que tu vas comprendre et intégrer.

Et pour finir, le trait [Display](https://doc.rust-lang.org/std/fmt/trait.Display.html), je vois que tu tentes de faire une implémentation de quelque chose dans le genre
```
1 2 3
4 5 6
```
malheureusement, il y a une possibilité pour que tu es mal compris une chose à cause de moi, si c'est le cas sorry. Mais sinon le fonctionnement de Display (et de Debug par la même occasion) c'est pas réellement lier à print lui-même, mais plus à la macro [`format!`](https://doc.rust-lang.org/std/macro.format.html). La macro format comme avec le `sprintf` du C va te générer une chaine de caractère en remplaçant certain élément (avec `sprintf` le `%d` va être remplacé par un nombre), pour le `format!`, c'est plus ou moins la même affaire, le format va créer un flux d'écriture dans une `String` et y écrit petit à petit la chaine, et lorsqu'il rencontre `{}` il va alors essayer d'y mettre une valeur hors il ne sait pas comment faire alors, on utilise le trait `Display`, il va donc faire appel à une méthode qui va permettre de décrire comment il doit écrire dans le flux. La macro `write!` elle prend en paramètre un flux (dans le cas du Display c'est un `std::fmt::Formatter`) et il va écrire à l'intérieur avec la contenue passer par les arguments d'après.

(tu n'as pas besoin d'utiliser les `self.inner.len()` et `self.inner[i].len()` comme tu as $N$ et $M$ qui sont déjà tes 2 constantes)

J'espère que tu as pu apprendre ou comprendre 2/3 trucs et que j'ai pu t'aider sur certaine chose ^^.